### PR TITLE
ログイン・ログアウト処理の実装

### DIFF
--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -138,12 +138,13 @@ class _LoginPageState extends State<LoginPage> {
       MaterialPageRoute(builder: (context) => HomePage()),
       );
   }else{
-    print('postが失敗しました');
+    // ログイン処理失敗時、SnackBar（画面下にエラー文表示）を出力する
     ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('ログインに失敗しました'),
-          backgroundColor: Colors.red,
-        ),);
+      SnackBar(
+        content: Text('ログインに失敗しました'),
+        backgroundColor: Colors.red,
+      ),
+    );
   }
 }
 }

--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -17,6 +17,7 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   late TextEditingController _emailController;
   late TextEditingController _passwordController;
+  bool _isObscure = true;
 
   // 入力内容取得のためのコントローラーinitメソッド
   @override
@@ -38,47 +39,79 @@ class _LoginPageState extends State<LoginPage> {
   // 入力内容：メールアドレス、パスワード
   @override
   Widget build(BuildContext context) {
+    const _formKey=GlobalObjectKey<FormState>('FORM_KEY');
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('ログイン画面'),
         backgroundColor: Colors.deepOrange[300],
       ),
       body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              margin: const EdgeInsets.all(20),
-              // メールアドレス入力フォーム
-              child: TextFormField(
-                controller: _emailController,
-                decoration: const InputDecoration(
-                  label: Text('メールアドレス'),
-                  fillColor: Colors.black,
+        child: Form(
+          key:_formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                margin: const EdgeInsets.all(20),
+                // メールアドレス入力フォーム
+                child: TextFormField(
+                  controller: _emailController,
+                  validator: (value){
+                    // メールアドレス形式の正規表現
+                    final emailPattern = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+                    if(value == null || value.isEmpty || !emailPattern.hasMatch(value)){
+                      return 'メールアドレスを入力してください';
+                    }
+                    return null;
+                  },
+                  decoration: const InputDecoration(
+                    label: Text('メールアドレス'),
+                    fillColor: Colors.black,
+                  ),
                 ),
               ),
-            ),
-            Container(
-              margin: const EdgeInsets.all(20),
-              // パスワード入力フォーム
-              child: TextFormField(
-                controller: _passwordController,
-                decoration: const InputDecoration(
-                  label: Text('パスワード'),
+              Container(
+                margin: const EdgeInsets.all(20),
+                // パスワード入力フォーム
+                child: TextFormField(
+                  controller: _passwordController,
+                  validator: (value){
+                    if(value == null || value.isEmpty){
+                      return 'パスワードを入力してください';
+                    }
+                    return null;
+                  },
+                  obscureText: _isObscure,
+                  decoration: InputDecoration(
+                    label: Text('パスワード'),
+                    suffixIcon: IconButton(
+                      icon: Icon(_isObscure ? Icons.visibility_off : Icons.visibility),
+                      onPressed: () {
+                        setState(() => _isObscure = !_isObscure
+                        );
+                      },
+                    )
+                  ),
                 ),
               ),
-            ),
-            // ログインボタン
-            // 押下時、ログイン処理する
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                foregroundColor: Colors.white,
-                backgroundColor: Colors.deepOrange[300],
+              // ログインボタン
+              // 押下時、ログイン処理する
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  foregroundColor: Colors.white,
+                  backgroundColor: Colors.deepOrange[300],
+                ),
+                onPressed: (){
+                  if(_formKey.currentState!.validate()){
+                    print('バリデーションOK');
+                    login(_emailController.text,_passwordController.text);
+                  }
+                },
+                child: const Text('ログイン'),
               ),
-              onPressed: ()=>login(_emailController.text,_passwordController.text),
-              child: const Text('ログイン'),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -1,8 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:rakuraku_reserve_front/pages/home_page.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
 
-class LoginPage extends StatelessWidget {
-  const LoginPage({super.key});
+class LoginPage extends StatefulWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  _LoginPageState createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  late TextEditingController _emailController;
+  late TextEditingController _passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController = TextEditingController();
+    _passwordController = TextEditingController();
+  }
+
+    @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,6 +42,7 @@ class LoginPage extends StatelessWidget {
             Container(
               margin: const EdgeInsets.all(20),
               child: TextFormField(
+                controller: _emailController,
                 decoration: const InputDecoration(
                   label: Text('メールアドレス'),
                   fillColor: Colors.black,
@@ -27,6 +52,7 @@ class LoginPage extends StatelessWidget {
             Container(
               margin: const EdgeInsets.all(20),
               child: TextFormField(
+                controller: _passwordController,
                 decoration: const InputDecoration(
                   label: Text('パスワード'),
                 ),
@@ -37,12 +63,14 @@ class LoginPage extends StatelessWidget {
                 foregroundColor: Colors.white,
                 backgroundColor: Colors.deepOrange[300],
               ),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => HomePage()),
-                );
-              },
+              onPressed: ()=>login(_emailController.text,_passwordController.text)
+              // () {
+                // Navigator.push(
+                //   context,
+                //   MaterialPageRoute(builder: (context) => HomePage()),
+                // );
+              // }
+              ,
               child: const Text('ログイン'),
             ),
           ],
@@ -50,4 +78,26 @@ class LoginPage extends StatelessWidget {
       ),
     );
   }
+
+  Future<void> login(String email,password) async{
+  final url = Uri.parse('http://localhost:8080/api/login');
+  Map<String, String> headers = {'content-type': 'application/json'};
+  final response = await http.post(url, headers: headers,body: json.encode({
+        'email': email,
+        'password': password
+      }));
+  if(response.statusCode == 200){
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => HomePage()),
+      );
+  }
+  else{
+    print('postが失敗しました');
+    // ScaffoldMessenger.of(context).showSnackBar(
+    //     SnackBar(
+    //       content: Text('Failed to send POST request'),
+    //     ),);
+  }
+}
 }

--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -17,6 +17,7 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   late TextEditingController _emailController;
   late TextEditingController _passwordController;
+  // パスワード表示非表示フラグ
   bool _isObscure = true;
 
   // 入力内容取得のためのコントローラーinitメソッド
@@ -85,6 +86,8 @@ class _LoginPageState extends State<LoginPage> {
                   obscureText: _isObscure,
                   decoration: InputDecoration(
                     label: Text('パスワード'),
+                    // パスワード表示非表示実装
+                    // アイコン押下で_isObscureが反転する
                     suffixIcon: IconButton(
                       icon: Icon(_isObscure ? Icons.visibility_off : Icons.visibility),
                       onPressed: () {
@@ -104,7 +107,6 @@ class _LoginPageState extends State<LoginPage> {
                 ),
                 onPressed: (){
                   if(_formKey.currentState!.validate()){
-                    print('バリデーションOK');
                     login(_emailController.text,_passwordController.text);
                   }
                 },
@@ -137,10 +139,11 @@ class _LoginPageState extends State<LoginPage> {
       );
   }else{
     print('postが失敗しました');
-    // ScaffoldMessenger.of(context).showSnackBar(
-    //     SnackBar(
-    //       content: Text('Failed to send POST request'),
-    //     ),);
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('ログインに失敗しました'),
+          backgroundColor: Colors.red,
+        ),);
   }
 }
 }

--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -3,6 +3,7 @@ import 'package:rakuraku_reserve_front/pages/home_page.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
+// ログイン画面表示のためのクラス
 class LoginPage extends StatefulWidget {
   const LoginPage({Key? key}) : super(key: key);
 
@@ -10,10 +11,14 @@ class LoginPage extends StatefulWidget {
   _LoginPageState createState() => _LoginPageState();
 }
 
+// 画面表示内容
+// メールアドレス、パスワードの入力内容をPOSTする
+// ログインボタン押下時、loginメソッドでログイン処理する
 class _LoginPageState extends State<LoginPage> {
   late TextEditingController _emailController;
   late TextEditingController _passwordController;
 
+  // 入力内容取得のためのコントローラーinitメソッド
   @override
   void initState() {
     super.initState();
@@ -21,13 +26,16 @@ class _LoginPageState extends State<LoginPage> {
     _passwordController = TextEditingController();
   }
 
-    @override
+  // 入力内容取得のためのコントローラーdisposeメソッド
+  @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
     super.dispose();
   }
 
+  // 画面表示context指定メソッド
+  // 入力内容：メールアドレス、パスワード
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -41,6 +49,7 @@ class _LoginPageState extends State<LoginPage> {
           children: [
             Container(
               margin: const EdgeInsets.all(20),
+              // メールアドレス入力フォーム
               child: TextFormField(
                 controller: _emailController,
                 decoration: const InputDecoration(
@@ -51,6 +60,7 @@ class _LoginPageState extends State<LoginPage> {
             ),
             Container(
               margin: const EdgeInsets.all(20),
+              // パスワード入力フォーム
               child: TextFormField(
                 controller: _passwordController,
                 decoration: const InputDecoration(
@@ -58,19 +68,14 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               ),
             ),
+            // ログインボタン
+            // 押下時、ログイン処理する
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                 foregroundColor: Colors.white,
                 backgroundColor: Colors.deepOrange[300],
               ),
-              onPressed: ()=>login(_emailController.text,_passwordController.text)
-              // () {
-                // Navigator.push(
-                //   context,
-                //   MaterialPageRoute(builder: (context) => HomePage()),
-                // );
-              // }
-              ,
+              onPressed: ()=>login(_emailController.text,_passwordController.text),
               child: const Text('ログイン'),
             ),
           ],
@@ -79,6 +84,10 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  // ログイン処理のためのメソッド
+  // 入力されたメールアドレス、パスワードをBodyに入れPOST処理する
+  // ログイン成功時、200ステータスが返る
+  // Cookieにsession_idが格納される
   Future<void> login(String email,password) async{
   final url = Uri.parse('http://localhost:8080/api/login');
   Map<String, String> headers = {'content-type': 'application/json'};
@@ -86,13 +95,14 @@ class _LoginPageState extends State<LoginPage> {
         'email': email,
         'password': password
       }));
+  // ログイン成功時、ホームページに遷移する
+  // 失敗時、エラーメッセージを表示する
   if(response.statusCode == 200){
     Navigator.push(
       context,
       MaterialPageRoute(builder: (context) => HomePage()),
       );
-  }
-  else{
+  }else{
     print('postが失敗しました');
     // ScaffoldMessenger.of(context).showSnackBar(
     //     SnackBar(

--- a/rakuraku_reserve_front/pubspec.lock
+++ b/rakuraku_reserve_front/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -192,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -208,5 +232,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/rakuraku_reserve_front/pubspec.yaml
+++ b/rakuraku_reserve_front/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^1.2.1
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
# 実装内容
- ログイン画面の実装
  - 以下のバリデーション追加
    - email: メール形式、空文字
    - password: 空文字
  - パスワードの表示非表示
    > 入力箇所のアイコンをクリックすることで入力したパスワードが表示されます
  - ログイン失敗時、SnackBarの表示
    > 画面下にエラーメッセージ表示
# 実装詳細
- ログイン成功時
https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/2aa2a5b5-14ef-445f-bb73-377d7f37dfdd

- バリデーション処理
https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/f7a76dac-a223-4a21-8140-5a56bf940cf1

- ログイン失敗時、SnackBarの表示
https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/a5a7d2cb-899c-4e96-a526-a21c5fd92f29

# 備考
- mac環境で確認しているのでweb-serverをdocker上で起動してブラウザで画面表示しています。
- 上記に関連してflutterアプリのportを9080開けて確認しているのでバックエンド側でCORS設定をする必要があります。
- 詳細についてはこちらのIssueに記載しています。
