### PR TITLE
パスワード再設定メール送信処理の実装

### DIFF
--- a/rakuraku_reserve_front/lib/pages/login_page.dart
+++ b/rakuraku_reserve_front/lib/pages/login_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:rakuraku_reserve_front/pages/home_page.dart';
+import 'package:rakuraku_reserve_front/pages/send_reset_password_mail_page.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
@@ -40,7 +41,7 @@ class _LoginPageState extends State<LoginPage> {
   // 入力内容：メールアドレス、パスワード
   @override
   Widget build(BuildContext context) {
-    const _formKey=GlobalObjectKey<FormState>('FORM_KEY');
+    const _formKey=GlobalObjectKey<FormState>('LOGIN_FORM_KEY');
 
     return Scaffold(
       appBar: AppBar(
@@ -111,6 +112,15 @@ class _LoginPageState extends State<LoginPage> {
                   }
                 },
                 child: const Text('ログイン'),
+              ),
+              TextButton(
+                onPressed:(){
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => SendResetPasswordMailPage()),
+                    );
+                },
+                child: Text('パスワードを忘れた場合'),
               ),
             ],
           ),

--- a/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
+++ b/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
@@ -3,6 +3,7 @@ import 'package:rakuraku_reserve_front/pages/home_page.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
+// パスワード再設定メール送信画面
 class SendResetPasswordMailPage extends StatefulWidget {
   const SendResetPasswordMailPage({super.key});
 
@@ -27,6 +28,8 @@ class _SendResetPasswordMailPageState extends State<SendResetPasswordMailPage>  
     super.dispose();
   }
 
+  // パスワード再設定メール画面表示context指定メソッド
+  // 入力内容：メールアドレス
   @override
   Widget build(BuildContext context) {
     const _formKey=GlobalObjectKey<FormState>('SEND_RESET_PASSWORD_EMAIL_FORM_KEY');
@@ -97,7 +100,7 @@ class _SendResetPasswordMailPageState extends State<SendResetPasswordMailPage>  
     final response = await http.post(url, headers: headers,body: json.encode({
           'email': email,
         }));
-    // ログイン成功時、ホームページに遷移する
+    // パスワード再設定メール送信成功時、ホームページに遷移する
     // 失敗時、エラーメッセージを表示する
     if(response.statusCode == 200){
       Navigator.push(
@@ -105,7 +108,7 @@ class _SendResetPasswordMailPageState extends State<SendResetPasswordMailPage>  
         MaterialPageRoute(builder: (context) => HomePage()),
         );
     }else{
-      // ログイン処理失敗時、SnackBar（画面下にエラー文表示）を出力する
+      // パスワード再設定メール送信失敗時、SnackBar（画面下にエラー文表示）を出力する
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('パスワード再設定メールの送信に失敗しました'),

--- a/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
+++ b/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:rakuraku_reserve_front/pages/home_page.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class SendResetPasswordMailPage extends StatefulWidget {
+  const SendResetPasswordMailPage({super.key});
+
+  @override
+  State<SendResetPasswordMailPage> createState() => _SendResetPasswordMailPageState();
+}
+
+class _SendResetPasswordMailPageState extends State<SendResetPasswordMailPage>  {
+  late TextEditingController _emailController;
+
+    // 入力内容取得のためのコントローラーinitメソッド
+  @override
+  void initState() {
+    super.initState();
+    _emailController = TextEditingController();
+  }
+
+  // 入力内容取得のためのコントローラーdisposeメソッド
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const _formKey=GlobalObjectKey<FormState>('SEND_RESET_PASSWORD_EMAIL_FORM_KEY');
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('パスワード再設定メール送信画面'),
+        backgroundColor: Colors.deepOrange[300],
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: Center(
+        child: Form(
+          key:_formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                margin: const EdgeInsets.all(20),
+                // トークン送信するメールアドレス入力フォーム
+                child: TextFormField(
+                  controller: _emailController,
+                  validator: (value){
+                    // メールアドレス形式の正規表現
+                    final emailPattern = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+                    if(value == null || value.isEmpty || !emailPattern.hasMatch(value)){
+                      return 'パスワーそ再設定の案内を受け取る\nメールアドレスを入力してください';
+                    }
+                    return null;
+                  },
+                  decoration: const InputDecoration(
+                    label: Text('メールアドレス'),
+                    fillColor: Colors.black,
+                  ),
+                ),
+              ),
+              // メール送信ボタン
+              // 押下時、メール送信処理する
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  foregroundColor: Colors.white,
+                  backgroundColor: Colors.deepOrange[300],
+                ),
+                onPressed: (){
+                  if(_formKey.currentState!.validate()){
+                    sendResetPasswordEmail(_emailController.text);
+                  }
+                },
+                child: const Text('パスワード再設定メールを送信する'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // パスワード再設定メール送信するためのメソッド
+  // 入力されたメールアドレスをBodyに入れPOST処理する
+  // メール送信成功時、200ステータスが返る
+  Future<void> sendResetPasswordEmail(String email) async{
+    final url = Uri.parse('http://localhost:8080/api/users/forgot-password');
+    Map<String, String> headers = {'content-type': 'application/json'};
+    final response = await http.post(url, headers: headers,body: json.encode({
+          'email': email,
+        }));
+    // ログイン成功時、ホームページに遷移する
+    // 失敗時、エラーメッセージを表示する
+    if(response.statusCode == 200){
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => HomePage()),
+        );
+    }else{
+      // ログイン処理失敗時、SnackBar（画面下にエラー文表示）を出力する
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('パスワード再設定メールの送信に失敗しました'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+}

--- a/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
+++ b/rakuraku_reserve_front/lib/pages/send_reset_password_mail_page.dart
@@ -36,7 +36,7 @@ class _SendResetPasswordMailPageState extends State<SendResetPasswordMailPage>  
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('パスワード再設定メール送信画面'),
+        title: const Text('パスワード再設定\nメール送信画面'),
         backgroundColor: Colors.deepOrange[300],
         leading: IconButton(
           icon: Icon(Icons.arrow_back),


### PR DESCRIPTION
# 実装内容
- ログイン画面ボタン下部に「パスワードを忘れた場合」ボタンの追加
- パスワード再設定メール送信画面作成
  - メールアドレス入力後、POSTする
  - バリデーション
    - メールアドレス：メールアドレス形式、空文字
  - パスワード再設定画面に遷移（予定）
- 画面右上の戻るボタン「←」でログイン画面に戻る
- メール送信失敗時、SnackBarで「パスワード再設定メールを送信する」を表示させる

# 実装詳細
- メール送信成功時
![画面収録-2024-03-27-10 57 28](https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/54299c5d-37c4-489a-9847-bf2e8d83ee55)

- バリデーション時
![画面収録-2024-03-27-11 02 07](https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/3d6bc170-857e-4529-b1a2-6462582808b4)

- メール送信失敗時
![画面収録-2024-03-27-11 03 19](https://github.com/tetsu-777/rakuraku-flutter/assets/118358124/2e619916-4eb7-4660-9a3c-39e6f103f7ad)

# 備考
- パスワード再設定画面については別プルリクで実装します。
- メール送信失敗時、場合分けをするか検討中